### PR TITLE
Add new commands and documentation for Kjell bot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Kjell is a Telegram group bot written in Python. It uses the `python-telegram-bo
 ## Running the bot
 
 ```bash
+pip install -r requirements.txt
 python main.py
 ```
 
@@ -53,6 +54,6 @@ Commands register themselves at import time using decorators from `bot/register_
 
 `utils/debug.py` configures stdlib logging at the level set in `utils/constants.py` (`LOG_LEVEL = 'INFO'`). The `error` handler catches all unhandled exceptions, stores the latest traceback in a module-level variable (retrievable with `/error`), and forwards the full traceback to `DEBUG_CHAT_ID`.
 
-## Known issues
+## Weather location
 
-`commands/random.py` references `./pics/intefredag/` and `./pics/fredagsgrodan/` but the actual images live at `resources/pics/intefredag/` and `resources/pics/fredagsgrodan/`. The `/fredag` command will fail unless the bot is run from `resources/` or the paths are corrected.
+`utils/constants.py` contains `WEATHER_LAT` and `WEATHER_LON` (default: Stockholm). Change these to match your group's location. The `/vader` command uses SMHI's free open-data API, which only covers Sweden.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Kjell is a Telegram group bot written in Python. It uses the `python-telegram-bot` library and integrates with Google Calendar. The bot is written primarily in Swedish.
+
+## Running the bot
+
+```bash
+python main.py
+```
+
+There is no test suite. The bot must be run live against the Telegram API to verify behavior.
+
+## Required secrets
+
+`utils/secret.py` is gitignored and must be created manually with:
+- `API_TOKEN` — Telegram bot token
+- `CHAT_ID` — the primary group chat ID
+- `DEBUG_CHAT_ID` — where error tracebacks are sent
+- `CALENDAR_ID` — Google Calendar ID
+
+Google Calendar also requires `service.json` (service account credentials file) in the project root.
+
+## Architecture
+
+### Handler registration via decorators
+
+Commands register themselves at import time using decorators from `bot/register_handlers.py`:
+
+- `@command_handler(command, description, admin_only)` — registers a `/command` handler. If `description` is provided it appears in the Telegram command list. Pass any truthy third argument to make it admin-only.
+- `@message_handler(filter)` — registers a handler triggered by message content (not a slash command).
+- `@conversation_handler(commands_dict, states, fallbacks)` — registers a multi-step `ConversationHandler`.
+
+`commands/__init__.py` imports every command module, which triggers all decorator registrations. `main.py` then imports `commands` to load everything before starting the bot.
+
+### Adding a new command
+
+1. Create `commands/mycommand.py` with an `async def` function decorated with `@command_handler`.
+2. Add `import commands.mycommand` to `commands/__init__.py`.
+
+### Bot startup sequence
+
+`main.py` → imports `bot` and `commands` (handlers register) → adds error handler → schedules `alive()` job (10s delay, registers command list and announces startup) → schedules `sync_calendar` repeating job (every 30s) → starts polling.
+
+### Calendar sync
+
+`calendar_client/sync_events.py` polls Google Calendar every 30 seconds using an incremental sync token stored in `sync_token.pickle`. New, updated, or cancelled events are sent as formatted messages to `CHAT_ID`.
+
+### Logging and errors
+
+`utils/debug.py` configures stdlib logging at the level set in `utils/constants.py` (`LOG_LEVEL = 'INFO'`). The `error` handler catches all unhandled exceptions, stores the latest traceback in a module-level variable (retrievable with `/error`), and forwards the full traceback to `DEBUG_CHAT_ID`.
+
+## Known issues
+
+`commands/random.py` references `./pics/intefredag/` and `./pics/fredagsgrodan/` but the actual images live at `resources/pics/intefredag/` and `resources/pics/fredagsgrodan/`. The `/fredag` command will fail unless the bot is run from `resources/` or the paths are corrected.

--- a/bot/register_handlers.py
+++ b/bot/register_handlers.py
@@ -48,9 +48,6 @@ def conversation_handler(
     """
     Register a conversation handler.
     """
-    print(type(commands), commands)
-    print(type(states), states)
-    print(type(fallbacks), fallbacks)
     logger.info(
         "Adding ConversationHandler with commands: %s, states: %s, and fallbacks: %s",
         commands, states, fallbacks
@@ -58,9 +55,6 @@ def conversation_handler(
     def decorator(func: Callable) -> Callable:
         command = commands.get('command')
         entry_points = [CommandHandler(command, func)]
-        print(type(entry_points), entry_points)
-        print(type(states), states)
-        print(type(fallbacks), fallbacks)
         handler = ConversationHandler(entry_points, states, fallbacks)
         application.add_handler(handler)
         if commands.get('description'):

--- a/commands/__init__.py
+++ b/commands/__init__.py
@@ -7,3 +7,8 @@ import commands.link
 import commands.random
 import commands.skatt
 import commands.time
+import commands.kalender
+import commands.paminn
+import commands.vader
+import commands.rost
+import commands.triggers

--- a/commands/event.py
+++ b/commands/event.py
@@ -14,9 +14,15 @@ from telegram.ext import (ContextTypes, ConversationHandler, MessageHandler,
 from utils import logger
 from utils.secret import CALENDAR_ID
 
-CREDENTIALS = calendar_credentials()
-CALENDAR = GoogleCalendar(default_calendar=CALENDAR_ID, credentials=CREDENTIALS)
 DETAILS, SUBMIT = range(2)
+_calendar = None
+
+
+def _get_calendar() -> GoogleCalendar:
+    global _calendar
+    if _calendar is None:
+        _calendar = GoogleCalendar(default_calendar=CALENDAR_ID, credentials=calendar_credentials())
+    return _calendar
 EVENT_KEYBOARD = [
     ["Namn"],
     ["Datum", "Start tid", "Slut tid"],
@@ -127,7 +133,7 @@ async def event_submit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         if user_data.get('Beskrivning'):
             event.description = user_data.get('Beskrivning')
         try:
-            CALENDAR.add_event(event)
+            _get_calendar().add_event(event)
             await update.message.reply_text("Aight", reply_markup=ReplyKeyboardRemove())
             user_data.clear()
             return ConversationHandler.END

--- a/commands/kalender.py
+++ b/commands/kalender.py
@@ -1,0 +1,46 @@
+# pylint: disable=unused-argument
+
+from datetime import datetime, timedelta
+
+from bot import command_handler
+from calendar_client.authenticate_calendar import calendar_credentials
+from gcsa.google_calendar import GoogleCalendar
+from telegram import Update, constants
+from telegram.ext import ContextTypes
+from utils import logger
+from utils.secret import CALENDAR_ID
+
+_calendar = None
+
+
+def _get_calendar() -> GoogleCalendar:
+    global _calendar
+    if _calendar is None:
+        _calendar = GoogleCalendar(default_calendar=CALENDAR_ID, credentials=calendar_credentials())
+    return _calendar
+
+
+@command_handler("kalender", "Kommande händelser i kalendern")
+async def kalender(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    logger.debug("Trigger command_handler %s", __name__)
+    try:
+        cal = _get_calendar()
+        now = datetime.now()
+        events = list(cal.get_events(
+            time_min=now,
+            time_max=now + timedelta(days=60),
+            order_by='startTime',
+            single_events=True,
+        ))[:5]
+        if not events:
+            await update.message.reply_text("Inga kommande händelser 📭")
+            return
+        lines = []
+        for event in events:
+            start = event.start
+            date_str = start.strftime("%d/%m %H:%M") if isinstance(start, datetime) else start.strftime("%d/%m")
+            lines.append(f"📅 <b>{event.summary}</b> – <code>{date_str}</code>")
+        await update.message.reply_text("\n".join(lines), parse_mode=constants.ParseMode.HTML)
+    except Exception as e:
+        logger.error("Kalender error: %s", e)
+        await update.message.reply_text("Kunde inte hämta kalendern 😢")

--- a/commands/paminn.py
+++ b/commands/paminn.py
@@ -1,0 +1,37 @@
+# pylint: disable=unused-argument
+
+import re
+
+from bot import command_handler
+from telegram import Update, constants
+from telegram.ext import ContextTypes
+from utils import logger
+
+_TIME_RE = re.compile(r'^(\d+)(m|h|d)$')
+_UNITS = {'m': 60, 'h': 3600, 'd': 86400}
+
+
+@command_handler("paminn", "Sätt en påminnelse: /paminn 30m Köp mjölk")
+async def paminn(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    logger.debug("Trigger command_handler %s", __name__)
+    if not context.args or len(context.args) < 2:
+        await update.message.reply_text("Användning: /paminn <tid> <meddelande>\nEx: /paminn 30m Köp mjölk")
+        return
+    match = _TIME_RE.match(context.args[0])
+    if not match:
+        await update.message.reply_text("Ogiltig tid. Använd t.ex. 30m, 2h, 1d")
+        return
+    seconds = int(match.group(1)) * _UNITS[match.group(2)]
+    text = " ".join(context.args[1:])
+    chat_id = update.message.chat_id
+    user = update.effective_user.mention_html()
+
+    async def _callback(ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        await ctx.bot.send_message(
+            chat_id=chat_id,
+            text=f"⏰ Påminnelse för {user}: {text}",
+            parse_mode=constants.ParseMode.HTML,
+        )
+
+    context.job_queue.run_once(_callback, seconds)
+    await update.message.reply_text(f"⏰ Påminnelse satt om {context.args[0]}!")

--- a/commands/random.py
+++ b/commands/random.py
@@ -69,14 +69,14 @@ trav_list =  [
 async def fredag(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     logger.debug("Trigger command_handler %s", __name__)
     await update.message.reply_text("Fredag?")
-    directory = './pics/intefredag/'
+    directory = 'resources/pics/intefredag/'
     message = 'Nepp'
     if (datetime.today().weekday() == 4):
         message = 'Haha aa de ere'
-        directory = './pics/fredagsgrodan/'
+        directory = 'resources/pics/fredagsgrodan/'
     file = open(os.path.join(directory, random.choice(os.listdir(directory))), 'rb')
-    await context.bot.send_message(chat_id=context._chat_id, text=message)
-    await context.bot.send_photo(chat_id=context._chat_id, photo=file)
+    await context.bot.send_message(chat_id=update.message.chat_id, text=message)
+    await context.bot.send_photo(chat_id=update.message.chat_id, photo=file)
 
 @command_handler("herrskrynkel", "Herr skrynkel pls")
 async def skrynkel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/commands/rost.py
+++ b/commands/rost.py
@@ -1,0 +1,26 @@
+# pylint: disable=unused-argument
+
+from bot import command_handler
+from telegram import Update
+from telegram.ext import ContextTypes
+from utils import logger
+
+
+@command_handler("rost", "Skapa en omröstning: /rost Fråga? | Alt1 | Alt2")
+async def rost(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    logger.debug("Trigger command_handler %s", __name__)
+    if not context.args:
+        await update.message.reply_text("Användning: /rost Fråga? | Alt1 | Alt2 | Alt3")
+        return
+    parts = [p.strip() for p in " ".join(context.args).split("|")]
+    if len(parts) < 3:
+        await update.message.reply_text("Du behöver en fråga och minst två alternativ separerade med |")
+        return
+    question = parts[0][:300]
+    options = [o[:100] for o in parts[1:11]]
+    await context.bot.send_poll(
+        chat_id=update.message.chat_id,
+        question=question,
+        options=options,
+        is_anonymous=False,
+    )

--- a/commands/triggers.py
+++ b/commands/triggers.py
@@ -1,0 +1,15 @@
+# pylint: disable=unused-argument
+
+import random
+
+from bot import message_handler
+from commands.random import citat_list
+from telegram import Update
+from telegram.ext import ContextTypes, filters
+from utils import logger
+
+
+@message_handler(filters.Regex(r'(?i)\bkjell\b') & ~filters.COMMAND)
+async def kjell_trigger(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    logger.debug("Trigger message_handler %s", __name__)
+    await update.message.reply_text(random.choice(citat_list))

--- a/commands/triggers.py
+++ b/commands/triggers.py
@@ -4,12 +4,34 @@ import random
 
 from bot import message_handler
 from commands.random import citat_list
-from telegram import Update
+from telegram import ReactionTypeEmoji, Update
 from telegram.ext import ContextTypes, filters
 from utils import logger
+
+_REACTION_EMOJIS = [
+    "👍", "👎", "❤", "🔥", "🥰", "👏", "😁", "🤔", "🤯", "😱",
+    "🤬", "😢", "🎉", "🤩", "🤮", "💩", "🙏", "👌", "🕊", "🤡",
+    "🥱", "🥴", "😍", "🐳", "❤️‍🔥", "🌚", "🌭", "💯", "🤣", "⚡",
+    "🍌", "🏆", "💔", "🤨", "😐", "🍓", "🍾", "💋", "🖕", "😈",
+    "😴", "😭", "🤓", "👻", "👨‍💻", "👀", "🎃", "🙈", "😇", "😨",
+    "🤝", "✍", "🤗", "🫡", "🎅", "🎄", "☃", "💅", "🤪", "🗿",
+    "🆒", "💘", "🙉", "🦄", "😘", "💊", "🙊", "😎", "👾", "🤷‍♂️",
+    "🤷", "🤷‍♀️", "😡",
+]
 
 
 @message_handler(filters.Regex(r'(?i)\bkjell\b') & ~filters.COMMAND)
 async def kjell_trigger(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     logger.debug("Trigger message_handler %s", __name__)
     await update.message.reply_text(random.choice(citat_list))
+
+
+@message_handler(~filters.COMMAND)
+async def random_reaction(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if random.random() >= 0.01:
+        return
+    emoji = random.choice(_REACTION_EMOJIS)
+    try:
+        await update.message.set_reaction([ReactionTypeEmoji(emoji=emoji)])
+    except Exception:
+        pass

--- a/commands/vader.py
+++ b/commands/vader.py
@@ -1,0 +1,47 @@
+# pylint: disable=unused-argument
+
+import requests
+from bot import command_handler
+from telegram import Update
+from telegram.ext import ContextTypes
+from utils import logger
+from utils.constants import WEATHER_LAT, WEATHER_LON
+
+_SYMBOLS = {
+    1: "☀️ Klart", 2: "🌤 Mest klart", 3: "⛅️ Variabel molnighet",
+    4: "🌥 Halvklart", 5: "☁️ Molnigt", 6: "☁️ Mulet", 7: "🌫 Dimma",
+    8: "🌦 Lätta regnskurar", 9: "🌧 Måttliga regnskurar", 10: "🌧 Kraftiga regnskurar",
+    11: "⛈ Åskväder", 12: "🌨 Snöblandade skurar", 13: "🌨 Snöblandade skurar",
+    14: "🌨 Kraftiga snöblandade skurar", 15: "🌨 Lätta snöbyar", 16: "❄️ Måttliga snöbyar",
+    17: "❄️ Kraftiga snöbyar", 18: "🌧 Lätt regn", 19: "🌧 Måttligt regn",
+    20: "🌧 Kraftigt regn", 21: "⛈ Åska", 22: "🌨 Lätt snöblandat regn",
+    23: "🌨 Måttligt snöblandat regn", 24: "🌨 Kraftigt snöblandat regn",
+    25: "❄️ Lätt snöfall", 26: "❄️ Måttligt snöfall", 27: "❄️ Kraftigt snöfall",
+}
+
+
+def _param(parameters: list, name: str):
+    for p in parameters:
+        if p['name'] == name:
+            return p['values'][0]
+    return None
+
+
+@command_handler("vader", "Aktuellt väder")
+async def vader(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    logger.debug("Trigger command_handler %s", __name__)
+    url = (
+        f"https://opendata-download-metfcst.smhi.se/api/category/pmp3g/version/2"
+        f"/geotype/point/lon/{WEATHER_LON}/lat/{WEATHER_LAT}/data.json"
+    )
+    response = requests.get(url, timeout=10)
+    if response.status_code != 200:
+        await update.message.reply_text("Kunde inte hämta väderdata 🌧")
+        return
+    data = response.json()
+    params = data['timeSeries'][0]['parameters']
+    temp = _param(params, 't')
+    wind = _param(params, 'ws')
+    symbol = int(_param(params, 'Wsymb2') or 0)
+    desc = _SYMBOLS.get(symbol, "?")
+    await update.message.reply_text(f"{desc}\n🌡 {temp}°C\n💨 {wind} m/s")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+python-telegram-bot[job-queue]
+requests
+google-auth
+google-api-python-client
+google-calendar-simple-api
+pytz
+python-dateutil

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,3 +1,6 @@
 LOG_LEVEL = 'INFO'
 VERSION = '0.4'
-TEST = True
+
+# Default weather location (Stockholm). Change to match your group's city.
+WEATHER_LAT = 59.3293
+WEATHER_LON = 18.0686


### PR DESCRIPTION
## Summary
This PR adds four new Telegram bot commands, comprehensive documentation for developers, and refactors calendar initialization to use lazy loading.

## Key Changes

- **New Commands**
  - `/vader` — Fetches current weather from SMHI's open-data API with temperature, wind speed, and weather symbol
  - `/kalender` — Displays the next 5 upcoming calendar events from Google Calendar
  - `/paminn` — Sets reminders with flexible time syntax (e.g., `30m`, `2h`, `1d`)
  - `/rost` — Creates polls with pipe-separated questions and options

- **Message Handlers**
  - Added trigger for "kjell" mentions that replies with random quotes
  - Added 1% chance random emoji reactions to all messages

- **Documentation**
  - Added `CLAUDE.md` with comprehensive guidance on bot architecture, handler registration patterns, startup sequence, and configuration

- **Refactoring**
  - Converted global `CALENDAR` instance in `commands/event.py` to lazy-loaded `_get_calendar()` function to prevent initialization errors
  - Applied same pattern to `commands/kalender.py` for consistency
  - Fixed file paths in `commands/random.py` from `./pics/` to `resources/pics/`
  - Fixed `fredag()` command to use `update.message.chat_id` instead of `context._chat_id`

- **Configuration**
  - Added `WEATHER_LAT` and `WEATHER_LON` constants to `utils/constants.py` (defaulting to Stockholm)
  - Added `requirements.txt` with all project dependencies

- **Code Quality**
  - Removed debug `print()` statements from `bot/register_handlers.py`
  - Updated `commands/__init__.py` to import all new command modules

https://claude.ai/code/session_01PENpw9GjPHoyioVFfxFwok