### PR TITLE
Update weather API to use SMHI snow1g dataset

### DIFF
--- a/commands/vader.py
+++ b/commands/vader.py
@@ -20,18 +20,11 @@ _SYMBOLS = {
 }
 
 
-def _param(parameters: list, name: str):
-    for p in parameters:
-        if p['name'] == name:
-            return p['values'][0]
-    return None
-
-
 @command_handler("vader", "Aktuellt väder")
 async def vader(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     logger.debug("Trigger command_handler %s", __name__)
     url = (
-        f"https://opendata-download-metfcst.smhi.se/api/category/pmp3g/version/2"
+        f"https://opendata-download-metfcst.smhi.se/api/category/snow1g/version/1"
         f"/geotype/point/lon/{WEATHER_LON}/lat/{WEATHER_LAT}/data.json"
     )
     response = requests.get(url, timeout=10)
@@ -39,9 +32,9 @@ async def vader(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         await update.message.reply_text("Kunde inte hämta väderdata 🌧")
         return
     data = response.json()
-    params = data['timeSeries'][0]['parameters']
-    temp = _param(params, 't')
-    wind = _param(params, 'ws')
-    symbol = int(_param(params, 'Wsymb2') or 0)
+    entry = data['timeSeries'][0]['data']
+    temp = entry.get('air_temperature')
+    wind = entry.get('wind_speed')
+    symbol = int(entry.get('symbol_code') or 0)
     desc = _SYMBOLS.get(symbol, "?")
     await update.message.reply_text(f"{desc}\n🌡 {temp}°C\n💨 {wind} m/s")


### PR DESCRIPTION
## Summary
Updates the `/vader` weather command to use SMHI's `snow1g` API endpoint instead of `pmp3g`, and refactors the parameter extraction logic to work with the new API response structure.

## Changes
- **API endpoint migration**: Changed from `pmp3g/version/2` to `snow1g/version/1` to use SMHI's snow forecast dataset
- **Response parsing refactor**: Replaced the `_param()` helper function with direct dictionary access using `.get()` on the API response structure
  - Old approach: extracted parameters from `timeSeries[0]['parameters']` array
  - New approach: accesses data directly from `timeSeries[0]['data']` object
- **Field name updates**: Updated parameter names to match the new API schema:
  - `t` → `air_temperature`
  - `ws` → `wind_speed`
  - `Wsymb2` → `symbol_code`
- **Code simplification**: Removed the `_param()` function entirely as it's no longer needed with the new API structure

## Implementation Details
The new `snow1g` endpoint returns weather data in a flatter structure where parameters are direct keys in the data object rather than array elements, allowing for simpler and more readable code.

https://claude.ai/code/session_01PENpw9GjPHoyioVFfxFwok